### PR TITLE
add 8085 build

### DIFF
--- a/makefile.cpm
+++ b/makefile.cpm
@@ -22,6 +22,6 @@ cpmterm.o: cpmterm.c zmodem.h zmdm.h
 cpmfile.o: cpmfile.c fileio.h
 
 clean:
-	rm -f *.o *.lis *.map zmtx zmrx zmtx.com zmrx.com
+	rm -f *.o *.lis *.map zmtx zmrx ZMTX.COM ZMRX.COM
 
 

--- a/makefile.cpm.8085
+++ b/makefile.cpm.8085
@@ -23,5 +23,3 @@ cpmfile.o: cpmfile.c fileio.h
 
 clean:
 	rm -f *.o *.lis *.map zmtx zmrx ZMTX.COM ZMRX.COM
-
-

--- a/makefile.cpm.8085
+++ b/makefile.cpm.8085
@@ -1,7 +1,7 @@
 # To compile using SDCC, add '-compiler=sdcc' to CC and remove -Werror from CFLAGS.
 
 CC=zcc +cpm
-CFLAGS := -O2 --list -Wall -Werror
+CFLAGS := -clib=8085 -O2 --list -D__CLASSIC -D__8085__ -Wall -Werror
 
 all:	zmrx.com zmtx.com
 
@@ -22,6 +22,6 @@ cpmterm.o: cpmterm.c zmodem.h zmdm.h
 cpmfile.o: cpmfile.c fileio.h
 
 clean:
-	rm -f *.o *.lis *.map zmtx zmrx zmtx.com zmrx.com
+	rm -f *.o *.lis *.map zmtx zmrx ZMTX.COM ZMRX.COM
 
 

--- a/zmtx.c
+++ b/zmtx.c
@@ -27,6 +27,8 @@
 
 #define MAX_SUBPACKETSIZE 1024
 
+#pragma printf = "%c %s %d %ld"         // enables %c, %s, %d, %ld only
+
 extern int use_aux;
 
 int opt_v = FALSE;                      /* show progress output */
@@ -37,7 +39,6 @@ int n_files_remaining;
 unsigned char tx_data_subpacket[1024];
 
 long current_file_size;
-time_t transfer_start;
 
 /*
  * show the progress of the transfer like this:
@@ -47,8 +48,6 @@ time_t transfer_start;
 void show_progress(char *name, FILE *fp)
 
 {
-    time_t duration;
-    long cps;
     long percentage;
 
     if (current_file_size > 0) {
@@ -57,18 +56,10 @@ void show_progress(char *name, FILE *fp)
         percentage = 100;
     }
 
-    duration = time(NULL) - transfer_start;
-
-    if (duration == 0l) {
-        duration = 1l;
-    }
-
-    cps = (long)ftell(fp) / duration;
-
     fprintf(
         stderr,
-        "zmtx: sending file \"%s\" %8ld bytes (%3ld %%/%5ld cps)           \r",
-        name, ftell(fp), percentage, cps);
+        "zmtx: sending file \"%s\" %8ld bytes (%3ld %%)           \r",
+        name, ftell(fp), percentage);
 }
 
 /*
@@ -293,7 +284,7 @@ int send_file(char *name)
      * modification date
      */
 
-    sprintf(p, "%lo ", fileio_get_modification_time(name));
+    sprintf(p, "%ld ", fileio_get_modification_time(name));
 
     p += strlen(p);
 
@@ -356,8 +347,6 @@ int send_file(char *name)
         }
 
     } while (type != ZRPOS);
-
-    transfer_start = time(NULL);
 
     do {
         /*


### PR DESCRIPTION
I've added some simple options to build for 8085 CP/M.

~~Unfortunately there are no `time()` or `clock()` functions implemented for INTEL processors, and they're not part of the CP/M 2.2 BDOS anyway, so I've just deleted those pieces of the code. https://github.com/z88dk/z88dk/issues/1966~~

__EDIT__ reverted `time()` function deletes because I've now added stubs for CP/M 2.2 to z88dk.

Added a `#pragma` to configure the stdio prints. In the classic library the format conversion routines will be simple, unless the (any) width is included. So `%8ld` is required to get the width calculation code for `long` included.

You're welcome to just cherry-pick and close this PR if you like. :smile: 